### PR TITLE
Add quick & dirty Python2/Python3 compatibility

### DIFF
--- a/default.py
+++ b/default.py
@@ -3,9 +3,14 @@ import xbmc, xbmcaddon, xbmcgui
 
 __addon__    = xbmcaddon.Addon()
 __addonid__  = __addon__.getAddonInfo('id')
-__cwd__      = __addon__.getAddonInfo('path').decode("utf-8")
+__cwd__      = __addon__.getAddonInfo('path')
 __language__ = __addon__.getLocalizedString
-__resource__ = xbmc.translatePath( os.path.join( __cwd__, 'resources', 'lib' ).encode("utf-8") ).decode("utf-8")
+__resource__ = xbmc.translatePath( os.path.join( __cwd__, 'resources', 'lib' ).encode('utf-8') )
+
+# Hack: Python2/Python3 fix
+if sys.version_info.major < 3:
+  __cwd__ = __cwd__.decode('utf-8')
+  __resource__ = __resource__.decode('utf-8')
 
 sys.path.append(__resource__)
 

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -4,9 +4,15 @@ import xbmc, xbmcgui, xbmcaddon
 __addon__    = sys.modules[ '__main__' ].__addon__
 __addonid__  = sys.modules[ '__main__' ].__addonid__
 __cwd__      = sys.modules[ '__main__' ].__cwd__
-__skindir__  = xbmc.getSkinDir().decode('utf-8')
-__skinhome__ = xbmc.translatePath( os.path.join( 'special://home/addons/', __skindir__, 'addon.xml' ).encode('utf-8') ).decode('utf-8')
-__skinxbmc__ = xbmc.translatePath( os.path.join( 'special://xbmc/addons/', __skindir__, 'addon.xml' ).encode('utf-8') ).decode('utf-8')
+__skindir__  = xbmc.getSkinDir()
+__skinhome__ = xbmc.translatePath( os.path.join( 'special://home/addons/', __skindir__, 'addon.xml' ).encode('utf-8') )
+__skinxbmc__ = xbmc.translatePath( os.path.join( 'special://xbmc/addons/', __skindir__, 'addon.xml' ).encode('utf-8') )
+
+# Hack: Python2/Python3 fix
+if sys.version_info.major < 3:
+  __skindir__ = __skindir__.decode('utf-8')
+  __skinhome__ = __skinhome__.decode('utf-8')
+  __skinxbmc__ = __skinxbmc__.decode('utf-8')
 
 class Screensaver(xbmcgui.WindowXMLDialog):
     def __init__( self, *args, **kwargs ):


### PR DESCRIPTION
Current version is not working with Python3 (`'str' object has no attribute 'decode'`).

No doubt there's a more elegant/Pythonic solution, in which case if it materialises please close this effort of mine! :)

Tested with Python2 and Python3 based Kodi (LibreELEC).