### PR TITLE
silence classes left in memory noise

### DIFF
--- a/default.py
+++ b/default.py
@@ -19,3 +19,4 @@ if __name__ == '__main__':
     screensaver_gui = gui.Screensaver('dummy.xml', __cwd__, 'default')
     screensaver_gui.doModal()
     del screensaver_gui
+    __addon__ = __addonid__ = __cwd__ = __language__ = __resource__ = None


### PR DESCRIPTION
When disabling the screensaver, kodi logs the following:
```
2020-01-28 09:42:14.234 T:1622 WARNING: CPythonInvoker(32, /storage/.kodi/addons/script.pydisplaypower/default.py): the python script "/storage/.kodi/addons/script.pydisplaypower/default.py" has left several classes in memory that we couldn't clean up. The classes include: N9XBMCAddon9xbmcaddon5AddonE
```
This change stops this message appearing.